### PR TITLE
Add template math documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,16 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "myst_parser",
+    "sphinx.ext.mathjax",
 ]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+myst_enable_extensions = ["amsmath"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,5 @@ documentation for details.
    :maxdepth: 2
    :caption: Contents:
 
+   math
+

--- a/docs/math.md
+++ b/docs/math.md
@@ -1,0 +1,16 @@
+# Math Derivations
+
+This page demonstrates how to include mathematics using Markdown and LaTeX syntax with MyST.
+
+A simple inline equation: $E = mc^2$.
+
+A displayed equation using ``$$`` syntax:
+
+$$\int_0^1 x^2\,dx = \frac{1}{3}$$
+
+A displayed equation using the ``math`` directive:
+
+```{math}
+a^2 + b^2 = c^2
+```
+


### PR DESCRIPTION
## Summary
- enable MyST and MathJax extensions for Sphinx
- link to new math doc page from the index
- add a `math.md` template page with example equations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vice_squad')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including Markdown files in the documentation, alongside reStructuredText.
  - Enabled rendering of mathematical expressions in documentation using MathJax and enhanced math syntax in Markdown.
  - Introduced a new "Math" section in the documentation with examples of mathematical notation.

- **Documentation**
  - Updated the documentation index to include the new "Math" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->